### PR TITLE
Support cross-origin auth flows by using the postMessage() system

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,34 @@ The Client ID and Redirect URI should match that of the client app.
 
 Then you can run `npm start`.
 
+### Cross Origin / Same-origin Policy
+
+> See the documentation on [Same-origin policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy)
+
+If you are using the Authorization Code flow, and your redirect URL is on a server with a different
+domain to your frontend, you will need to do the following:
+
+1. Set the `isCrossOrigin` property to `true`
+2. Set up your authorization url on your server to return a standard response similar to the one
+   below:
+
+```
+<html>
+<head></head>
+<body>
+  <script>
+    window.addEventListener("message", function (event) {
+      if (event.data.message === "requestResult") {
+        event.source.postMessage({"message": "deliverResult", result: {...} }, "*");
+      }
+    });
+  </script>
+</body>
+</html>
+```
+
+Your server needs to populate the `result` key with an object to deliver back to the frontend.
+
 ### Props
 
 #### `authorizationUrl`
@@ -124,6 +152,13 @@ CSS class for the login button.
 `{string}`
 
 Text content for the login button.
+
+#### `isCrossOrigin`
+
+`{bool}`
+
+Is this a cross-origin request? If you are implementing an Authorization Code workflow and your
+server backend is on a different URL, you'll need to set this to true.
 
 #### `render`
 

--- a/src/OAuth2Login.jsx
+++ b/src/OAuth2Login.jsx
@@ -25,7 +25,7 @@ class OAuth2Login extends Component {
 
   onBtnClick() {
     const {
-      buttonText, authorizationUrl, clientId, scope, redirectUri, state, responseType,
+      buttonText, authorizationUrl, clientId, scope, redirectUri, state, responseType, isCrossOrigin
     } = this.props;
     const payload = {
       client_id: clientId,
@@ -50,6 +50,7 @@ class OAuth2Login extends Component {
       },
       {
         locationKey,
+        isCrossOrigin
       },
     );
     this.popup = popup;
@@ -68,7 +69,9 @@ class OAuth2Login extends Component {
   onSuccess(data) {
     const { responseType, onSuccess } = this.props;
     const responseKey = responseTypeDataKeys[responseType];
-    if (!data[responseKey]) {
+
+    // Cross origin requests will already handle this, let's just return the data
+    if (!this.props.isCrossOrigin && !data[responseKey]) {
       console.error('received data', data);
       return this.onFailure(new Error(`'${responseKey}' not found in received data`));
     }
@@ -103,6 +106,7 @@ OAuth2Login.defaultProps = {
   className: '',
   children: null,
   render: null,
+  isCrossOrigin: false,
   onRequest: () => {},
 };
 
@@ -117,6 +121,7 @@ OAuth2Login.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   render: PropTypes.func,
+  isCrossOrigin: PropTypes.bool,
   onRequest: PropTypes.func,
   scope: PropTypes.string,
   state: PropTypes.string,

--- a/src/PopupWindow.js
+++ b/src/PopupWindow.js
@@ -6,10 +6,23 @@ class PopupWindow {
     this.url = url;
     this.popupOptions = popupOptions;
     this.locationKey = otherOptions.locationKey;
+    this.isCrossOrigin = otherOptions.isCrossOrigin;
+    this.response = null;
+    this.handlePostMessage = this.handlePostMessage.bind(this);
+  }
+
+  handlePostMessage(event) {
+    if (event.data.message === "deliverResult") {
+      this.response = event.data.result;
+    }
   }
 
   open() {
-    const { url, id, popupOptions } = this;
+    const { url, id, popupOptions, isCrossOrigin } = this;
+
+    if (isCrossOrigin) {
+      window.addEventListener("message", this.handlePostMessage);
+    }
 
     this.window = window.open(url, id, toQuery(popupOptions, ','));
   }
@@ -17,6 +30,7 @@ class PopupWindow {
   close() {
     this.cancel();
     this.window.close();
+    window.removeEventListener("message", this.handlePostMessage);
   }
 
   poll() {
@@ -33,26 +47,41 @@ class PopupWindow {
             return;
           }
 
-          if (popup.location.href === this.url || popup.location.pathname === 'blank') {
-            // location unchanged, still polling
-            return;
+          // Cross origin auth flows need to be handled differently
+          if (this.isCrossOrigin) {
+            if (this.response) {
+              resolve(this.response);
+              this.close();
+            }
+            else {
+              popup.postMessage({message: "requestResult"}, "*");
+              return;
+            }
           }
+          else {
+            if (popup.location.href === this.url || popup.location.pathname === 'blank') {
+              // location unchanged, still polling
+              return;
+            }
+            if (!['search', 'hash'].includes(this.locationKey)) {
+              reject(new Error(`Cannot get data from location.${this.locationKey}, check the responseType prop`));
+              this.close();
+              return;
+            }
 
-          if (!['search', 'hash'].includes(this.locationKey)) {
-            reject(new Error(`Cannot get data from location.${this.locationKey}, check the responseType prop`));
+            const locationValue = popup.location[this.locationKey];
+            const params = toParams(locationValue);
+            resolve(params);
             this.close();
-            return;
           }
-          const locationValue = popup.location[this.locationKey];
-          const params = toParams(locationValue);
-          resolve(params);
-
-          this.close();
         } catch (error) {
-          /*
-           * Ignore DOMException: Blocked a frame with origin from accessing a
-           * cross-origin frame.
-           */
+          // Log the error to the console but remain silent
+          if (error.name === 'SecurityError' && error.message.includes('Blocked a frame with origin')) {
+            console.warn('Encountered a cross-origin error, is your authorization URL on a different server? Use the "isCrossOrigin" property, see documentation for details.');
+          }
+          else {
+            console.error(error);
+          }
         }
       }, 500);
     });


### PR DESCRIPTION
In my scenario, I have an API server on a different domain to my React frontend, and so using the Authorization Code workflow results in DOMExceptions (as seen in #19). By specifying isCrossOrigin and handling the resultant data via `postMessage()` gets around the issue (and is the recommended way to do it).