### PR TITLE
feat: add extra params prop to ferry to auth url query params

### DIFF
--- a/src/OAuth2Login.jsx
+++ b/src/OAuth2Login.jsx
@@ -35,12 +35,14 @@ class OAuth2Login extends Component {
       popupWidth,
       popupHeight,
       isCrossOrigin,
+      extraParams,
     } = this.props;
     const payload = {
       client_id: clientId,
       scope,
       redirect_uri: redirectUri,
       response_type: responseType,
+      ...extraParams,
     };
     if (state) {
       payload.state = state;
@@ -126,6 +128,7 @@ OAuth2Login.defaultProps = {
   popupHeight: 680,
   render: null,
   isCrossOrigin: false,
+  extraParams: {},
   onRequest: () => {},
 };
 
@@ -147,6 +150,7 @@ OAuth2Login.propTypes = {
   onRequest: PropTypes.func,
   scope: PropTypes.string,
   state: PropTypes.string,
+  extraParams: PropTypes.object,
 };
 
 export default OAuth2Login;


### PR DESCRIPTION
Some oauth providers allow for additional query params that change their popup behaviour.
For example Google allows a `prompt=consent` query param that forces the user to have to choose the google account with each popup to cover case where the user has logged out of your site but not Google.